### PR TITLE
Fix scikit-learn requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
     "ont_fast5_api >= 1.1",
     "tqdm",
     "ont-pyguppy-client-lib",
-    "sklearn",
+    "scikit-learn",
     "seaborn"
 ]
 


### PR DESCRIPTION
The correct PyPI package is [scikit-learn](https://pypi.org/project/scikit-learn), not [sklearn](https://pypi.org/project/sklearn) (which says: "Use scikit-learn instead").