### PR TITLE
use help command to test samtools

### DIFF
--- a/megalodon/mapping.py
+++ b/megalodon/mapping.py
@@ -267,44 +267,40 @@ class MapInfo:
 
     def test_samtools(self):
         try:
-            test_sort_res = subprocess.run(
-                [self.samtools_exec, "sort"],
+            test_help_res = subprocess.run(
+                [self.samtools_exec, "help"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-            test_index_res = subprocess.run(
-                [self.samtools_exec, "index"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            # Note index returns non-zero exit status
-            if test_sort_res.returncode != 0:
-                LOGGER.warning(
-                    "Samtools test commands return non-zero exit "
-                    + "status. Mappings will not be sorted or indexed."
-                )
-                LOGGER.debug(
-                    (
-                        "MappingTestFail:   sort_returncode: {}   "
-                        + "index_returncode: {}\nsort_call_stdout:\n{}\n"
-                        + "sort_call_stderr:\n{}\nindex_call_stdout:\n{}"
-                        + "\nindex_call_stderr:\n{}"
-                    ).format(
-                        test_sort_res.returncode,
-                        test_index_res.returncode,
-                        test_sort_res.stdout.decode(),
-                        test_sort_res.stderr.decode(),
-                        test_index_res.stdout.decode(),
-                        test_index_res.stderr.decode(),
-                    )
-                )
-                self.do_sort_mappings = False
         except FileNotFoundError:
             LOGGER.warning(
                 "Samtools executable not found. Mappings will "
                 + "not be sorted or indexed."
             )
             self.do_sort_mappings = False
+        else:
+            if test_help_res.returncode != 0:
+                LOGGER.warning(
+                    "Samtools test commands return non-zero exit "
+                    + "status. Mappings will not be sorted or indexed."
+                )
+                LOGGER.debug(
+                    (
+                        "MappingTestFail:   samtools_returncode: {}   "
+                        + "\nsamtools_call_stdout:\n{}"
+                        + "\nsamtools_call_stderr:\n{}"
+                    ).format(
+                        test_help_res.returncode,
+                        test_help_res.stdout.decode(),
+                        test_help_res.stderr.decode(),
+                    )
+                )
+                self.do_sort_mappings = False
+            else:
+                LOGGER.debug(
+                    "Mapping Test Success --- Mappings will be "
+                    + "sorted and indexed with samtools"
+                )
 
 
 def align_read(


### PR DESCRIPTION
This PR updates the samtools test to use the command `samtools help`. This command fulfills the purpose of sanity checking the installation of SAMtools in a more reliable way than `samtools sort` and `samtools index`:
* `samtools sort` can cause a false negative on correct installations under some conditions, such as the environment inside a computational job in our HPC cluster (Slurm). In those cases `samtools sort` fails with an exit code 1 and the output
    ```
    samtools sort: failed to read header from "-"
    ```
* `samtools index` always returns an exit code 1

This PR also limits the code in `try` to the execution of SAMtools and moves all code that should only be executes if the `try` is successful (*i.e.* the command `samtools` exists) into the `else` statement.